### PR TITLE
Update SWR to v1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "sharp": "0.29.3",
-    "swr": "1.0.1"
+    "swr": "1.1.1"
   },
   "devDependencies": {
     "@tailwindcss/forms": "0.4.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,17 +4,13 @@ import 'nprogress/nprogress.css';
 import { DefaultSeo } from 'next-seo';
 import useNProgress from 'next-use-nprogress';
 import Script from 'next/script';
-import { SWRConfig } from 'swr';
 
 import { CommonLayout } from '@src/frontend/components/layout';
 import { Modal, Notification } from '@src/frontend/components/ui';
 import { useModal } from '@src/frontend/hooks/use-modal';
 import { useNoti } from '@src/frontend/hooks/use-noti';
-import { fetcher } from '@src/frontend/lib/fetcher';
 
 import type { AppProps } from 'next/app';
-
-const fetcherSWR = async (url: string) => await fetcher(url).json();
 
 export default function App({ Component, pageProps }: AppProps) {
   useNProgress({
@@ -75,11 +71,9 @@ export default function App({ Component, pageProps }: AppProps) {
           },
         ]}
       />
-      <SWRConfig value={{ fetcher: fetcherSWR }}>
-        <CommonLayout>
-          <Component {...pageProps} />
-        </CommonLayout>
-      </SWRConfig>
+      <CommonLayout>
+        <Component {...pageProps} />
+      </CommonLayout>
 
       <Modal {...modal} close={closeModal} />
       <Notification {...noti} close={closeNoti} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,11 +2274,6 @@ depd@^1.1.0, depd@~1.1.2:
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-dequal@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
-  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
-
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz"
@@ -6577,12 +6572,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-swr@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.1.tgz#15f62846b87ee000e52fa07812bb65eb62d79483"
-  integrity sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==
-  dependencies:
-    dequal "2.0.2"
+swr@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.1.1.tgz#f13346cc830d7950183af57b341bfabb4cc90d43"
+  integrity sha512-ZpUHyU3N3snj2QGFeE2Fd3BXl1CVS6YQIQGb1ttPAkTmvwZqDyV3GRMNPsaeAYCBM74tfn4XbKx28FVQR0mS7Q==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
we'd better use swr like this

```ts
const getData = async () => {
  return await fetcher.get(endPoint, { ...options }).json();
}

const { data, mutate } = useSWR(SWR_KEY_DATA, getData, { ...swrOptions });

...
```